### PR TITLE
Few small fixes and improvements

### DIFF
--- a/brother_printer_fwupd/__main__.py
+++ b/brother_printer_fwupd/__main__.py
@@ -7,7 +7,11 @@ import argparse
 import sys
 import typing
 
-from .autodiscover_printer import PrinterDiscoverer
+try:
+    from .autodiscover_printer import PrinterDiscoverer
+except ImportError:
+    PrinterDiscoverer = None
+
 from .firmware_downloader import download_fw, get_download_url
 from .firmware_uploader import upload_fw
 from .snmp_info import get_snmp_info
@@ -24,12 +28,19 @@ def parse_args():
         prog=__file__,
         description=__doc__.strip().splitlines()[0],
     )
+    if PrinterDiscoverer is None:
+        discovery_available = False
+        blurb = "required, because zeroconf is not available"
+    else:
+        discovery_available = True
+        blurb = "default: autodiscover via mdns"
     parser.add_argument(
         "-p",
         "--printer",
+        required=not discovery_available,
         metavar="host",
         default=None,
-        help="IP Address or hostname of the printer (default: autodiscover via mdns).",
+        help=f"IP Address or hostname of the printer ({blurb}).",
     )
     parser.add_argument(
         "--community",

--- a/brother_printer_fwupd/__main__.py
+++ b/brother_printer_fwupd/__main__.py
@@ -35,13 +35,19 @@ def parse_args():
         "--community",
         "-c",
         default="public",
-        help="SNMP Community string for the printer (default: 'public').",
+        help="SNMP Community string for the printer (default: '%(default)s').",
     )
     parser.add_argument(
         "--fw-file",
         "-f",
         default="firmware.djf",
-        help="File name for the downloaded firmware (default: 'firmware.djf').",
+        help="File name for the downloaded firmware (default: '%(default)s').",
+    )
+    parser.add_argument(
+        "--os",
+        type=str.upper,
+        choices=["WINDOWS", "MAC", "LINUX"],
+        help="Operating system to report when downloading firmware (default: autodetect)",
     )
 
     return parser.parse_args()
@@ -82,6 +88,7 @@ def main():
         download_url = get_download_url(
             printer_info=printer_info,
             firmid=str(fw_part.firmid),
+            reported_os=args.os,
         )
 
         if not download_url:

--- a/brother_printer_fwupd/__main__.py
+++ b/brother_printer_fwupd/__main__.py
@@ -75,7 +75,7 @@ def main():
     print_info(
         f" Detected {printer_info.model} with following firmware version(s): {versions_str}"
     )
-    print_info("Querying firmware download URL from brother update API.")
+    print_info("Querying firmware download URL from Brother update API.")
     download_url: typing.Optional[str] = None
 
     for fw_part in printer_info.fw_versions:

--- a/brother_printer_fwupd/autodiscover_printer.py
+++ b/brother_printer_fwupd/autodiscover_printer.py
@@ -7,8 +7,8 @@ import ipaddress
 import typing
 
 import termcolor
-import zeroconf
 
+import zeroconf
 from .models import MDNSPrinterInfo
 from .utils import clear_screen, print_debug, print_error
 

--- a/brother_printer_fwupd/firmware_downloader.py
+++ b/brother_printer_fwupd/firmware_downloader.py
@@ -75,7 +75,7 @@ def get_download_url(
 
     path = resp_xml.find("PATH")
     if not path:
-        print_error("Did not receive download url for {firmid}.")
+        print_error(f"Did not receive download url for {firmid}.")
         print_error("Either this firmware part is up to date or there is a bug.")
         print_error("This is the response of Brother's update API:")
         print_error(resp.text)

--- a/brother_printer_fwupd/firmware_downloader.py
+++ b/brother_printer_fwupd/firmware_downloader.py
@@ -69,7 +69,7 @@ def get_download_url(
         else:
             print_error(f"Unknown versioncheck response for {firmid=}.")
             print_error("There seems to be a bug. Open an issue!")
-            print_error("This is the response of brothers update API:")
+            print_error("This is the response of Brother's update API:")
             print_error(resp.text)
             return None
 
@@ -77,7 +77,7 @@ def get_download_url(
     if not path:
         print_error("Did not receive download url for {firmid}.")
         print_error("Either this firmware part is up to date or there is a bug.")
-        print_error("This is the response of brothers update API:")
+        print_error("This is the response of Brother's update API:")
         print_error(resp.text)
         return None
 

--- a/brother_printer_fwupd/firmware_downloader.py
+++ b/brother_printer_fwupd/firmware_downloader.py
@@ -1,4 +1,5 @@
 """Logic to download the correct firmware from the official Brother server."""
+import sys
 import typing
 
 import requests
@@ -15,7 +16,8 @@ FW_UPDATE_URL = (
 
 
 def get_download_url(
-    printer_info: "SNMPPrinterInfo", firmid: str = "MAIN"
+    printer_info: "SNMPPrinterInfo", firmid: str = "MAIN",
+    reported_os: typing.Optional[str] = None
 ) -> typing.Optional[str]:
     """Get the firmware download URL for the target printer. """
     firm_info = ""
@@ -27,11 +29,20 @@ def get_download_url(
             <VERSION>{fw_info.firmver}</VERSION>
         </FIRM>
         """
+
+    if reported_os is None:
+        if sys.platform.startswith("win") or sys.platform.startswith("cygwin"):
+            reported_os = "WINDOWS"
+        elif sys.platform.startswith("darwin"):
+            reported_os = "MAC"
+        else:
+            reported_os = "LINUX"
+
     api_data = f"""
 <REQUESTINFO>
     <FIRMUPDATETOOLINFO>
         <FIRMCATEGORY>{firmid}</FIRMCATEGORY>
-        <OS>LINUX</OS>
+        <OS>{reported_os}</OS>
         <INSPECTMODE>1</INSPECTMODE>
     </FIRMUPDATETOOLINFO>
 

--- a/brother_printer_fwupd/firmware_downloader.py
+++ b/brother_printer_fwupd/firmware_downloader.py
@@ -16,10 +16,11 @@ FW_UPDATE_URL = (
 
 
 def get_download_url(
-    printer_info: "SNMPPrinterInfo", firmid: str = "MAIN",
-    reported_os: typing.Optional[str] = None
+    printer_info: "SNMPPrinterInfo",
+    firmid: str = "MAIN",
+    reported_os: typing.Optional[str] = None,
 ) -> typing.Optional[str]:
-    """Get the firmware download URL for the target printer. """
+    """Get the firmware download URL for the target printer."""
     firm_info = ""
 
     for fw_info in printer_info.fw_versions:

--- a/brother_printer_fwupd/models.py
+++ b/brother_printer_fwupd/models.py
@@ -10,6 +10,7 @@ IPAddress = typing.Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
 @dataclass
 class FWInfo:
     """Firmware fragment info."""
+
     firmid: typing.Optional[str] = field(default=None)
     firmver: typing.Optional[str] = field(default=None)
 

--- a/brother_printer_fwupd/snmp_info.py
+++ b/brother_printer_fwupd/snmp_info.py
@@ -20,7 +20,7 @@ from .utils import print_error
 
 SNMP_OID = "iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2"
 
-SNMP_RE = re.compile(r'(?P<name>[A-Z]+) ?= ?"(?P<value>.+)"')
+SNMP_RE = re.compile(r'(?P<name>[A-Z]+) ?= ?"(?P<value>.*)"')
 UDP_SNMP_PORT = 161
 
 
@@ -89,11 +89,12 @@ def get_snmp_info(
             elif name == "SPEC":
                 printer_info.spec = value
             elif name in ("FIRMID", "FIRMVER"):
-                setattr(fw_info, name.lower(), value)
+                if value:
+                    setattr(fw_info, name.lower(), value)
 
-                if fw_info.is_complete:
-                    printer_info.fw_versions.append(fw_info)
-                    fw_info = FWInfo()
+                    if fw_info.is_complete:
+                        printer_info.fw_versions.append(fw_info)
+                        fw_info = FWInfo()
 
     if not fw_info.is_empty:
         print_error(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requests = "^2.23.0"
 BeautifulSoup4 = "^4.9.1"
 Gooey = { version = "^1.0.3", optional = true }
 lxml = "^4.6.2"
-zeroconf = "^0.28.7"
+zeroconf = { version = "^0.28.7", optional = true }
 termcolor = "^1.1.0"
 
 [tool.poetry.dev-dependencies]
@@ -28,6 +28,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry.extras]
 graphical = ["Gooey"]
+autodiscover = ["zeroconf"]
 
 [tool.poetry.scripts]
 brother_printer_fwupd = 'brother_printer_fwupd.__main__:main'


### PR DESCRIPTION
* Capitalization/punctuation

* Missed an f in this f-string

* Need to be able to handle empty 'SPEC' values, and ignore empty 'FIRMID', 'FIRMVER' values
    
    My printer's SNMP details have an *empty* value for 'SPEC' (which needs to
    be parsed correctly for the firmware downloader), but also a pair of empty
    values for 'FIRMID'/'FIRMVER' (at the end of the list), which need to be
    ignored by the firmware downloader:
    
    ```
    $ snmpwalk -v 2c -c public 192.168.1.123 iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2
    iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2.1 = STRING: "MODEL=\"AB-1234 series\""
    iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2.2 = STRING: "SERIAL=\"A1B123456\""
    iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2.3 = STRING: "SPEC=\"\""
    iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2.4 = STRING: "FIRMID=\"MAIN\""
    iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2.5 = STRING: "FIRMVER=\"1.18\""
    iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2.6 = STRING: "FIRMID=\"BRNET\""
    iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2.7 = STRING: "FIRMVER=\"1.04\""
    iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2.8 = STRING: "FIRMID=\"\""
    iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2.9 = STRING: "FIRMVER=\"\""
    iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2.10 = STRING: "                                                    "
    iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2.11 = STRING: "                                                    "
    iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2.12 = STRING: "                                                    "
    iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2.13 = STRING: "                                                    "
    iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2.14 = STRING: "                                                    "
    iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2.15 = STRING: "                                                    "
    iso.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2.16 = STRING: "                                                    "
    ```
    
    This change addresses both.

* Report host OS when downloading firmware, and allow user to override with --os
    
    I'm not 100% sure if it ever makes a difference, but it seems like
    the host OS should be reported accurately when downloading firmware.
    However, since its purpose is unclear it may be useful to give the
    user an option to override.
    
    Currently, the OS options are 'WINDOWS', 'MAC', or 'LINUX', since those seem
    to be the three OS categories which Brother's website reports support for.

* Make zeroconf dependency optional

* Apply `black`