### PR TITLE
Use port 9100 as fallback default for firmware upload

### DIFF
--- a/brother_printer_fwupd/firmware_uploader.py
+++ b/brother_printer_fwupd/firmware_uploader.py
@@ -21,7 +21,11 @@ def upload_fw(
     cat LZ5413_P.djf | nc lp.local 9100
     ```
     """
-    port = port if port else socket.getservbyname(PORT_SERVICE_NAME)
+    if port is not None:
+        try:
+            port = socket.getservbyname(PORT_SERVICE_NAME)
+        except OSError:
+            port = 9100
     addr_info = socket.getaddrinfo(str(target), port, 0, 0, socket.SOL_TCP)[0]
     with socket.socket(addr_info[0], addr_info[1], 0) as sock:
         sock.connect(addr_info[4])


### PR DESCRIPTION
In the case when the printer was *not* autodiscovered (e.g.  IP address specified explicitly with `-p 192.168.1.234`), the parameter `port` will be `None`, and the intended default behavior will depend on the local system database (e.g. `/etc/protocols`) having an entry for `pdl-datastream`.

Add port 9100 as the intended fallback port when this is missing.

See https://github.com/sedrubal/brother_printer_fwupd/commit/831d9858#r141422105