### PR TITLE
Fallbacks and fixes

### DIFF
--- a/brother_printer_fwupd/__main__.py
+++ b/brother_printer_fwupd/__main__.py
@@ -14,7 +14,11 @@ from typing import Optional
 import termcolor
 
 from . import ISSUE_URL
-from .autodiscover_printer import PrinterDiscoverer
+try:
+    from .autodiscover_printer import PrinterDiscoverer
+except ImportError:
+    PrinterDiscoverer = None
+
 from .firmware_downloader import download_fw, get_download_url
 from .firmware_uploader import upload_fw
 from .models import FWInfo, SNMPPrinterInfo
@@ -41,13 +45,20 @@ def parse_args():
         prog=__file__,
         description=__doc__.strip().splitlines()[0],
     )
+    if PrinterDiscoverer is None:
+        discovery_available = False
+        blurb = "required, because zeroconf is not available"
+    else:
+        discovery_available = True
+        blurb = "default: autodiscover via mdns"
     parser.add_argument(
         "-p",
         "--printer",
+        required=not discovery_available,
         dest="printer",
         metavar="host",
         default=None,
-        help="IP Address or hostname of the printer (default: autodiscover via mdns).",
+        help=f"IP Address or hostname of the printer ({blurb})).",
     )
     parser.add_argument(
         "--model",

--- a/brother_printer_fwupd/__main__.py
+++ b/brother_printer_fwupd/__main__.py
@@ -9,6 +9,7 @@ import sys
 import typing
 import webbrowser
 from pathlib import Path
+from typing import Optional
 
 import termcolor
 
@@ -71,7 +72,7 @@ def parse_args():
         "--fw-versions",
         dest="fw_versions",
         nargs="*",
-        default=list[FWInfo](),
+        default=[],  # In Python 3.10+: list[FWInfo]
         type=FWInfo.from_str,
         help="Skip SNMP scanning by directly specifying the firmware parts to update.",
     )
@@ -166,8 +167,8 @@ def run(issue_reporter: GitHubIssueReporter):
 
     CONSOLE_LOG_HANDLER.setLevel(logging.DEBUG if args.debug else logging.INFO)
 
-    printer_ip: typing.Optional["IPAddress"] = args.printer
-    upload_port: int | None = None
+    printer_ip: Optional["IPAddress"] = args.printer
+    upload_port: Optional[int] = None
     use_snmp = (
         not args.model or not args.serial or not args.spec or not args.fw_versions
     )
@@ -224,7 +225,7 @@ def run(issue_reporter: GitHubIssueReporter):
         versions_str,
     )
     LOGGER.info("Querying firmware download URL from Brother update API.")
-    download_url: str | None = None
+    download_url: Optional[str] = None
 
     for fw_part in printer_info.fw_versions:
         LOGGER.info("Try to get information for firmware part %s", fw_part)

--- a/brother_printer_fwupd/autodiscover_printer.py
+++ b/brother_printer_fwupd/autodiscover_printer.py
@@ -5,6 +5,7 @@
 
 import ipaddress
 import typing
+from typing import Optional
 
 import termcolor
 import zeroconf
@@ -21,11 +22,11 @@ class PrinterDiscoverer(zeroconf.ServiceListener):
     """Discoverer of printers."""
 
     def __init__(self) -> None:
-        self._printers: list[MDNSPrinterInfo] = list[MDNSPrinterInfo]()
+        self._printers: List[MDNSPrinterInfo] = list()  # In Python 3.10+, list[MDNSPrinterInfo]
         self._zc = zeroconf.Zeroconf()
         self._mode = "CLI"
         self._invalid_answer = False
-        self._browser: zeroconf.ServiceBrowser | None = None
+        self._browser: Optional[zeroconf.ServiceBrowser] = None
 
     def remove_service(self, zc: zeroconf.Zeroconf, type_: str, name: str):
         LOGGER.debug(f"Service {name} removed")
@@ -185,10 +186,10 @@ class PrinterDiscoverer(zeroconf.ServiceListener):
                 attrs=["italic"],
             )
 
-    def run_cli(self) -> MDNSPrinterInfo | None:
+    def run_cli(self) -> Optional[MDNSPrinterInfo]:
         """Run as interactive terminal application."""
         self._mode = "CLI"
-        choice: int | None = None
+        choice: Optional[int] = None
         self._run()
         self._update_screen()
 

--- a/brother_printer_fwupd/firmware_downloader.py
+++ b/brother_printer_fwupd/firmware_downloader.py
@@ -223,3 +223,4 @@ def download_fw(
             print(f"\r{progress: 5.1f} %", end="", flush=True)
 
     print()
+    return out_file

--- a/brother_printer_fwupd/firmware_downloader.py
+++ b/brother_printer_fwupd/firmware_downloader.py
@@ -3,6 +3,7 @@
 import typing
 from copy import copy
 from pathlib import Path
+from typing import Optional, Tuple
 
 import requests
 from bs4 import BeautifulSoup, Tag
@@ -49,7 +50,7 @@ def get_download_url(
     printer_info: "SNMPPrinterInfo",
     reported_os: str,
     firmid: str = "MAIN",
-) -> tuple[str | None, str | None]:
+) -> Tuple[Optional[str], Optional[str]]:
     """
     Get the firmware download URL for the target printer.
 
@@ -75,7 +76,7 @@ def get_download_url(
 
         api_request_data.REQUESTINFO.FIRMUPDATEINFO.MODELINFO.FIRMINFO.append(firm_info)
 
-    errors: list[ValueError] = []
+    errors: List[ValueError] = []
 
     for modification_callback in (copy, apply_driver_ews, apply_api_misspelling):
         api_request_data_str = str(modification_callback(api_request_data))
@@ -104,7 +105,7 @@ def get_download_url(
     raise ExceptionGroup("Giving up fetching firmware.", errors)
 
 
-def parse_response(response: str, firmid: str) -> tuple[str | None, str | None]:
+def parse_response(response: str, firmid: str) -> Tuple[Optional[str], Optional[str]]:
     """
     Parse the API response and return a tuple of the latest version and the download URL.
     """

--- a/brother_printer_fwupd/firmware_uploader.py
+++ b/brother_printer_fwupd/firmware_uploader.py
@@ -2,6 +2,7 @@
 
 import socket
 from pathlib import Path
+from typing import Optional
 
 from .models import IPAddress
 
@@ -10,7 +11,7 @@ PORT_SERVICE_NAME = "pdl-datastream"
 
 def upload_fw(
     target: IPAddress,
-    port: int | None,
+    port: Optional[int],
     fw_file_path: Path = Path("firmware.djf"),
 ):
     """

--- a/brother_printer_fwupd/firmware_uploader.py
+++ b/brother_printer_fwupd/firmware_uploader.py
@@ -21,7 +21,7 @@ def upload_fw(
     cat LZ5413_P.djf | nc lp.local 9100
     ```
     """
-    if port is not None:
+    if port is None:
         try:
             port = socket.getservbyname(PORT_SERVICE_NAME)
         except OSError:

--- a/brother_printer_fwupd/models.py
+++ b/brother_printer_fwupd/models.py
@@ -3,10 +3,11 @@
 import argparse
 import ipaddress
 from dataclasses import dataclass, field
+from typing import List, Optional, Union
 
 import termcolor
 
-IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
 
 
 @dataclass
@@ -14,8 +15,8 @@ class FWInfo:
     """Firmware fragment info."""
 
     # TODO don't allow None here...
-    firmid: str | None = field(default=None)
-    firmver: str | None = field(default=None)
+    firmid: Optional[str] = field(default=None)
+    firmver: Optional[str] = field(default=None)
 
     @property
     def is_complete(self):
@@ -49,10 +50,10 @@ class FWInfo:
 class SNMPPrinterInfo:
     """Information about a printer."""
 
-    model: str | None = field(default=None)
-    serial: str | None = field(default=None)
-    spec: str | None = field(default=None)
-    fw_versions: list[FWInfo] = field(default_factory=list[FWInfo])
+    model: Optional[str] = field(default=None)
+    serial: Optional[str] = field(default=None)
+    spec: Optional[str] = field(default=None)
+    fw_versions: List[FWInfo] = field(default_factory=list)
 
 
 @dataclass
@@ -61,7 +62,7 @@ class MDNSPrinterInfo:
 
     ip_addr: IPAddress
     name: str
-    port: int | None
-    product: str | None
-    note: str | None
-    uuid: str | None
+    port: Optional[int]
+    product: Optional[str]
+    note: Optional[str]
+    uuid: Optional[str]

--- a/brother_printer_fwupd/utils.py
+++ b/brother_printer_fwupd/utils.py
@@ -11,6 +11,7 @@ import sys
 import traceback
 import typing
 from pathlib import Path
+from typing import Dict, List, Optional, Union
 from urllib.parse import urlencode
 
 import termcolor
@@ -19,6 +20,16 @@ try:
     from gooey import Gooey
 except ImportError:
     Gooey = None
+
+try:
+    from typing import Literal
+except ImportError:
+    class _Literal:
+        def __getitem__(self, item):
+            return item
+    Literal = _Literal()  # crutch for Python 3.6
+
+ExceptionGroup = getattr(__builtins__, 'ExceptionGroup', None)  # will be None until Python 3.11
 
 
 def gooey_if_exists(func):
@@ -42,7 +53,7 @@ class GitHubIssueReporter:
         self.handler_cb = handler_cb
         self._handler = logging.StreamHandler(stream=io.StringIO())
         self._handler.setLevel(logging.DEBUG)
-        self._context = dict[str, str | bool | list[str]]()
+        self._context: Dict[str, str | bool | List[str]] = {}  # In Python 3.10+, dict[str, str | bool | list[str]]()
 
     def __enter__(self):
         self._handler.stream.seek(0)
@@ -55,7 +66,7 @@ class GitHubIssueReporter:
         if not exc_class or exc_class in (SystemExit, KeyboardInterrupt):
             return
 
-        if isinstance(exc, ExceptionGroup):
+        if ExceptionGroup and isinstance(exc, ExceptionGroup):
             LOGGER.error("%s  Errors:", exc.message)
             for err in exc.exceptions:
                 LOGGER.error("  - %s", err)
@@ -128,12 +139,12 @@ class GitHubIssueReporter:
         self.handler_cb(report_url)
         sys.exit(1)
 
-    def set_context_data(self, key: str, value: str | bool | list[str]):
+    def set_context_data(self, key: str, value: Union[str, bool, List[str]]):
         self._context[key] = value
 
 
 def get_running_os() -> (
-    typing.Literal["WINDOWS"] | typing.Literal["MAC"] | typing.Literal["LINUX"]
+    Union[typing.Literal["WINDOWS"], typing.Literal["MAC"], typing.Literal["LINUX"]]
 ):
     if sys.platform.startswith("win") or sys.platform.startswith("cygwin"):
         return "WINDOWS"
@@ -143,7 +154,7 @@ def get_running_os() -> (
         return "LINUX"
 
 
-def add_logging_level(level_name: str, level_num: int, method_name: str | None = None):
+def add_logging_level(level_name: str, level_num: int, method_name: Optional[str] = None):
     """
     Comprehensively adds a new logging level to the `logging` module and the
     currently configured logging class.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requests = "^2.31.0"
 BeautifulSoup4 = "^4.12.0"
 Gooey = { version = "^1.0.8", optional = true }
 lxml = "^4.9.0"
-zeroconf = "^0.28.8"
+zeroconf = { "^0.28.8", optional = true }
 termcolor = "^1.1.0"
 
 [tool.poetry.group.dev.dependencies]
@@ -35,6 +35,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.extras]
 graphical = ["Gooey"]
+autodiscover = ["zeroconf"]
 
 [tool.poetry.scripts]
 brother_printer_fwupd = 'brother_printer_fwupd.__main__:main'


### PR DESCRIPTION
* [bug] Condition reversed in https://github.com/sedrubal/brother_printer_fwupd/pull/21/files#r1594590002

* [bug] download_fw was broken

   In order for firmware *uploading* to work, `download_fw` needs to return the
path of the downloaded firmware file.

* Use port 9100 as fallback default for firmware upload

   In the case when the printer was *not* autodiscovered (e.g.  IP address
   specified explicitly with `-p 192.168.1.234`), the parameter `port` will be
   `None`, and the intended default behavior will depend on the local system
   database (e.g. `/etc/protocols`) having an entry for `pdl-datastream`.

   Add port 9100 as the intended fallback port when this is missing.

   See https://github.com/sedrubal/brother_printer_fwupd/commit/831d9858#r141422105

*  Use type annotations in a way that remains compatible with Python 3.7+

   This requires using `Union` and `Optional` rather than `|`, and not using
subscripted Python type objects.  See discussion at
https://github.com/sedrubal/brother_printer_fwupd/issues/20#issuecomment-2081262876.

*  Make zeroconf dependency optional again

   In 9ca66c7, I made the zeroconf dependency optional. In 670eb045, it was
   made obligatory again, perhaps by accident.
